### PR TITLE
watch config file mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog for octkeys
 
 ## Unreleased changes
+
+- Feat: add watch config file option `--watch`
+
+## 0.1.0
+
+- first release

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ octkeys [options] [input-file]
            --version      Show version
   -v       --verbose      Enable verbose mode: verbosity level "debug"
   -F PATH  --dotssh=PATH  ssh config directory path instead of ~/.ssh
+           --watch        Enable watch mode
 
 $ octkeys -F example/.ssh example/.octkeys.yaml
+finish: write example/.ssh/authorized_keys
 ```
 
 ## Build

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import           Paths_octkeys          (version)
 import           RIO
 import           RIO.Directory          (getHomeDirectory)
+import           RIO.FilePath           (dropFileName, takeFileName)
 
 import           Configuration.Dotenv   (defaultConfig, loadFile)
 import           Data.Extensible
@@ -12,19 +13,24 @@ import           Mix
 import           Mix.Plugin.Logger      as MixLogger
 import           Octkeys.Cmd
 import           Octkeys.Env
+import           System.FSNotify        (Event (Modified))
+import qualified System.FSNotify        as FSNotify
 import qualified Version
 
 main :: IO ()
 main = withGetOpt' "[options] [input-file]" opts $ \r args usage -> do
   _ <- tryIO $ loadFile defaultConfig
+  let path = fromMaybe ".octkeys.yaml" $ listToMaybe args
   if | r ^. #help    -> hPutBuilder stdout (fromString usage)
      | r ^. #version -> hPutBuilder stdout (Version.build version)
-     | otherwise     -> runCmd r (listToMaybe args)
+     | r ^. #watch   -> runCmd r `withWatch` path
+     | otherwise     -> runCmd r path
   where
     opts = #help    @= helpOpt
         <: #version @= versionOpt
         <: #verbose @= verboseOpt
         <: #dotssh  @= dotsshOpt
+        <: #watch   @= watchOpt
         <: nil
 
 type Options = Record
@@ -32,6 +38,7 @@ type Options = Record
    , "version" >: Bool
    , "verbose" >: Bool
    , "dotssh"  >: (Maybe FilePath)
+   , "watch"   >: Bool
    ]
 
 helpOpt :: OptDescr' Bool
@@ -46,9 +53,12 @@ verboseOpt = optFlag ['v'] ["verbose"] "Enable verbose mode: verbosity level \"d
 dotsshOpt :: OptDescr' (Maybe FilePath)
 dotsshOpt = optLastArg ['F'] ["dotssh"] "PATH" "ssh config directory path instead of ~/.ssh"
 
-runCmd :: Options -> Maybe FilePath -> IO ()
+watchOpt :: OptDescr' Bool
+watchOpt = optFlag [] ["watch"] "Enable watch mode"
+
+runCmd :: Options -> FilePath -> IO ()
 runCmd opts path = do
-  config <- readConfig (fromMaybe ".octkeys.yaml" path)
+  config <- readConfig path
   dotssh <- dotsshDirectory (opts ^. #dotssh)
   let plugin = hsequence
              $ #logger <@=> MixLogger.buildPlugin logOpts
@@ -62,3 +72,15 @@ runCmd opts path = do
 dotsshDirectory :: MonadIO m => Maybe FilePath -> m FilePath
 dotsshDirectory (Just path) = pure path
 dotsshDirectory Nothing     = (<> "/.ssh") <$> getHomeDirectory
+
+withWatch :: (FilePath -> IO ()) -> FilePath -> IO ()
+withWatch act path = do
+  act path
+  FSNotify.withManager $ \mgr -> do
+    _ <- FSNotify.watchDir mgr dir (const True) act'
+    forever $ threadDelay 1_000_000
+  where
+    (dir, fileName) = (dropFileName path, takeFileName path)
+    act' event = case event of
+      Modified path' _ _ | fileName == takeFileName path' -> act path
+      _                                                   -> pure ()

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ default-extensions:
 dependencies:
 - base >= 4.7 && < 5
 - rio >= 0.1.1.0
+- fsnotify
 - cryptonite
 - extensible >= 0.6
 - memory


### PR DESCRIPTION
Add `--watch` option.
When enable this option, keep to detect config file changed and update authorized_keys. 

```
$ stack exec -- octkeys --verbose --watch -F example/.ssh example/.octkeys.yaml
2020-01-09 00:02:06.983422: [debug] start: build authorized_keys
@(src/Octkeys/Cmd.hs:17:3)
2020-01-09 00:02:08.620628: [info] finish: write example/.ssh/authorized_keys
@(src/Octkeys/Cmd.hs:25:3)
2020-01-09 00:02:17.844478: [debug] start: build authorized_keys
@(src/Octkeys/Cmd.hs:17:3)
2020-01-09 00:02:18.453300: [info] finish: write example/.ssh/authorized_keys
@(src/Octkeys/Cmd.hs:25:3)
2020-01-09 00:02:21.343595: [debug] start: build authorized_keys
@(src/Octkeys/Cmd.hs:17:3)
2020-01-09 00:02:23.059158: [info] finish: write example/.ssh/authorized_keys
@(src/Octkeys/Cmd.hs:25:3)
2020-01-09 00:02:26.209586: [debug] start: build authorized_keys
@(src/Octkeys/Cmd.hs:17:3)
```