### PR TITLE
use github.com/[user].keys url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 
 - Feat: add watch config file option `--watch`
+- Modify: use `github.com/[user].keys` instead of GitHub API
+- Misc: update LTS to 14.22
 
 ## 0.1.0
 

--- a/src/Octkeys/Cmd.hs
+++ b/src/Octkeys/Cmd.hs
@@ -29,7 +29,7 @@ collectKeys name allow = tryAny (GitHub.fetchKeys name) >>= \case
   Left err ->
     Mix.logError (buildErrMessage err) >> pure Nothing
   Right keys ->
-    pure $ findAllowKey allow (fmap (fromString . view #key) keys)
+    pure $ findAllowKey allow keys
   where
     buildErrMessage e =
       mconcat [ "cannot fetch ", display name, " keys: ", displayShow e ]

--- a/src/Octkeys/GitHub/User.hs
+++ b/src/Octkeys/GitHub/User.hs
@@ -2,19 +2,14 @@ module Octkeys.GitHub.User where
 
 import           RIO
 
-import           Data.Extensible
 import           Network.HTTP.Req (GET (..), https, req, runReq, (/:))
 import qualified Network.HTTP.Req as Req
+import qualified RIO.ByteString   as B
 
-type Key = Record
-  '[ "id"  >: Int
-   , "key" >: String
-   ]
-
-fetchKeys :: MonadIO m => Text -> m [Key]
+fetchKeys :: MonadIO m => Text -> m [ByteString]
 fetchKeys name = runReq Req.defaultHttpConfig $ do
-  resp <- req GET url Req.NoReqBody Req.jsonResponse header
-  pure $ Req.responseBody resp
+  resp <- req GET url Req.NoReqBody Req.bsResponse header
+  pure (B.split 10 $ Req.responseBody resp)
   where
-    url = https "api.github.com" /: "users" /: name /: "keys"
+    url = https "github.com" /: name <> ".keys"
     header = Req.header "User-Agent" "octkeys"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.19
+resolver: lts-14.22
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -36,7 +36,7 @@ packages:
     url: https://github.com/matsubara0507/mix.hs/archive/4978a33dec736799b30c14e215f7fa0f29fa2884.tar.gz
 snapshots:
 - completed:
-    size: 524155
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/19.yaml
-    sha256: 9f79f6494473c9b46911364b94c4b5ef19ca8d35ebf62e46697cf651f198ee19
-  original: lts-14.19
+    size: 524164
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/22.yaml
+    sha256: 7ad8f33179b32d204165a3a662c6269464a47a7e65a30abc38d01b5a38ec42c0
+  original: lts-14.22


### PR DESCRIPTION
use `https://github.com/[user].keys` instead of GitHub API for public keys.