### PR TITLE
Update LTS to 19.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ghc: ["8.10.7"]
+        ghc: ["9.0.2"]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.yaml
+++ b/package.yaml
@@ -69,5 +69,6 @@ tests:
     source-dirs: test
     dependencies:
     - octkeys
+    - hspec
     - tasty
     - tasty-hspec

--- a/src/Octkeys/SSH/Key.hs
+++ b/src/Octkeys/SSH/Key.hs
@@ -12,7 +12,7 @@ import           Data.ByteArray.Encoding (Base (Base64), convertFromBase,
                                           convertToBase)
 
 md5 :: ByteString -> Maybe String
-md5 = fmap show . (fingerprint @ MD5)
+md5 = fmap show . (fingerprint @MD5)
 
 sha256 :: ByteString -> Maybe String
 sha256 = fmap (filter (/= '=') . T.unpack . textDisplay . displayBytesUtf8 . encode) . fingerprint

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,12 @@
-resolver: lts-18.13
+resolver: lts-19.5
 packages:
 - '.'
 extra-deps:
-- extensible-0.8.2
+- extensible-0.8.3
 - incremental-0.3.1
-- membership-0
+- membership-0.0.1
 - github: matsubara0507/mix.hs
-  commit: 75714be080db16f6a4f9d0a22e86947ffcdadc57
+  commit: 9bcd386526fe10a025a23e951c2de86b05129b17
   subdirs:
   - mix
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: extensible-0.8.2@sha256:f3e7497709199034222e10ba45d3730e21155fb89159ccf1fb0b55f1d7d02697,2963
+    hackage: extensible-0.8.3@sha256:2886978a81e9c2ff29a93caf7ae847a8b7724dc4ee22381c5d29ca8318c686c4,2955
     pantry-tree:
       size: 2041
-      sha256: 29d9d1cfb1c5348141f859e74739d212d3c5af9ff0ec359e3f66f872d4be8bc6
+      sha256: 670fd3807d351e2668eb7c10d926c24501ef190e49e4a4624acc822b09b257b4
   original:
-    hackage: extensible-0.8.2
+    hackage: extensible-0.8.3
 - completed:
     hackage: incremental-0.3.1@sha256:9c697bae4f7e5ceb144bde13e03ca2f36b4bc2d0c92bbc02e0a604231ee279c2,1153
     pantry-tree:
@@ -19,28 +19,28 @@ packages:
   original:
     hackage: incremental-0.3.1
 - completed:
-    hackage: membership-0@sha256:3a11d8fd53cb1a76bb9273e6c929bbf9d649f109714bf487abb3143be04ddc81,995
+    hackage: membership-0.0.1@sha256:6c4d4ab6e3fb3253c6c670e8a63f74454dc91be50b9f292d0b1355792190aee5,999
     pantry-tree:
       size: 408
-      sha256: 3b593e0d14e848e318e745555776ebb25210e5e3dec4fde5d3c08ab51ceddc62
+      sha256: b918a1a207108313b2bf453b0d9aa65122d9845c4b360c8ade46d3429ff1107a
   original:
-    hackage: membership-0
+    hackage: membership-0.0.1
 - completed:
-    size: 11913
+    size: 12123
     subdir: mix
-    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/9bcd386526fe10a025a23e951c2de86b05129b17.tar.gz
     name: mix
     version: 0.1.1
-    sha256: c4aa501c544ab35a214e7b07f2f97fb19de644f48874c8d6838809bcf4d8edb9
+    sha256: e6ddd7f45a74d368fede8656194fbf1dd9928a903852500c3c2cd4985d821649
     pantry-tree:
-      size: 598
-      sha256: 689bed307dc233a6c50e01f00295a079dc40a4291700646f3ca423d714ba35fc
+      size: 663
+      sha256: c1ead54fea3c786e356dadde2301de201599c10e18bc0be32aa8a2e3569930aa
   original:
     subdir: mix
-    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/9bcd386526fe10a025a23e951c2de86b05129b17.tar.gz
 snapshots:
 - completed:
-    size: 586268
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/13.yaml
-    sha256: d9e658a22cfe8d87a64fdf219885f942fef5fe2bcb156a9800174911c5da2443
-  original: lts-18.13
+    size: 619093
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/5.yaml
+    sha256: b936d27d647a31a8834d3efec126e2a07dee9c9bd6dd401d9bdac77e7b278f1e
+  original: lts-19.5

--- a/test/Spec/Octkeys/GitHub/User.hs
+++ b/test/Spec/Octkeys/GitHub/User.hs
@@ -3,6 +3,7 @@ module Spec.Octkeys.GitHub.User (spec) where
 import           RIO
 
 import qualified Octkeys.GitHub.User as GitHub
+import           Test.Hspec
 import           Test.Tasty.Hspec
 
 spec :: Spec

--- a/test/Spec/Octkeys/SSH/Key.hs
+++ b/test/Spec/Octkeys/SSH/Key.hs
@@ -4,7 +4,7 @@ import           RIO
 import qualified RIO.ByteString   as B
 
 import qualified Octkeys.SSH.Key  as SSHKey
-import           Test.Tasty.Hspec
+import           Test.Hspec
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
tasty-hspec-1.2 is dropped the Test.Hspec re-export.